### PR TITLE
add working link for shiny image

### DIFF
--- a/meetings/2017-01-19-intro-shiny/index.qmd
+++ b/meetings/2017-01-19-intro-shiny/index.qmd
@@ -9,7 +9,7 @@ date: 2017-01-19
 categories:
   - talks
   - shiny
-image: https://www.rstudio.com/assets/img/og/shiny-og-fb.jpg
+image: https://raw.githubusercontent.com/rstudio/shiny/refs/heads/main/man/figures/logo.png
 ---
 
 ## Resources:


### PR DESCRIPTION
url for Shiny-related image no longer working - replaced with one for hex Sticker on GitHub